### PR TITLE
Add the ability to hide the gui on startup via a command line flag

### DIFF
--- a/resources/js/window-provider.js
+++ b/resources/js/window-provider.js
@@ -14,6 +14,9 @@
  *  limitations under the License.
  */
 
+// Add a command line arg to see if the user wants to hide the gui on first launch
+let noGui = process.argv.indexOf("--no-gui") > -1;
+
  (function() {
   const { BrowserWindow, BrowserView, ipcMain, app } = require('electron')
 
@@ -34,17 +37,24 @@
       mainWindowState = windowStateKeeper( { defaultWidth: 1000, defaultHeight: 750 } )
       bounds = {
         title: "Pulse SMS", x: mainWindowState.x, y: mainWindowState.y,
-        width: mainWindowState.width, height: mainWindowState.height
+        width: mainWindowState.width, height: mainWindowState.height,
+        show : !noGui
       }
     } catch (err) {
       bounds = {
         title: "Pulse SMS", x: 0, y: 0,
-        width: 1000, height: 750
+        width: 1000, height: 750,
+        show : !noGui
       }
     }
 
     mainWindow = new BrowserWindow(bounds)
 
+    // always re-enable showing the GUI after first launch
+    if (noGui) {
+      noGui = false;
+    }
+    
     if (app.getLocale().indexOf("en") >= 0) {
       browserView = new BrowserView( { webPreferences: { nodeIntegration: false, preload: path.join(__dirname, 'spellcheck-preparer.js') } } )
     } else {


### PR DESCRIPTION
I throw pulse in my startup folder to have it startup when Windows starts up, though I'd like a way to not show the GUI during startup and instead go straight into the background.