### PR TITLE
Add the ability to set preferences from the tray-icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,21 @@
     "appId": "xyz.klinker.messenger",
     "productName": "Pulse SMS",
     "asar": true,
-    "asarUnpack": [ "**/dict/*" ],
+    "asarUnpack": [
+      "**/dict/*"
+    ],
     "artifactName": "pulse-sms-${version}-${arch}.${ext}",
     "mac": {
       "category": "public.app-category.utilities"
     },
-    "publish": [{
-      "provider": "github",
-      "owner": "klinker24",
-      "repo": "messenger-desktop",
-      "releaseType": "draft"
-    }]
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "klinker24",
+        "repo": "messenger-desktop",
+        "releaseType": "draft"
+      }
+    ]
   },
   "devDependencies": {
     "electron": "2.0.0-beta.7",

--- a/resources/js/menu.js
+++ b/resources/js/menu.js
@@ -15,11 +15,7 @@
  */
 const preferences = require('./preferences.js')
 
-// Save the preferencesMenu then reuse it later on.
-// This way we can use the same menu in the GUI and on the tray
-var preferencesMenu = {
-  label: 'Preferences',
-  submenu: [{
+var notificationPreferencesMenu = {
     label: 'Notification Preferences',
     submenu: [
       { label: "Show Notifications", type: 'checkbox', checked: preferences.showNotifications(), click() {
@@ -49,23 +45,9 @@ var preferencesMenu = {
         { label: "12 hours", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "12_hours", click() {
           preferences.snooze("12_hours") }
         }
-      ] }
-    ]
-  }, { type: 'separator' }, {
-    label: process.platform === 'darwin' ? 'Show in Menu Bar' : 'Show in Tray',
-    type: 'checkbox',
-    checked: preferences.minimizeToTray(),
-    click() {
-      let toTray = !preferences.minimizeToTray()
-      preferences.toggleMinimizeToTray()
-
-      if (!toTray && tray != null) {
-        tray.destroy()
-      } else {
-        tray = buildTray(windowProvider, webSocket)
-      }
+      ] 
     }
-  } ]
+  ]
 };
 
 (function() {
@@ -75,8 +57,24 @@ var preferencesMenu = {
   const browserviewPreparer = require('./browserview-configurator.js')
 
   var buildMenu = (windowProvider, tray, webSocket) => {
-    const template = [
-      preferencesMenu, {
+    const template = [{
+        label: 'Preferences',
+        submenu: [ notificationPreferencesMenu, { type: 'separator' }, {
+          label: process.platform === 'darwin' ? 'Show in Menu Bar' : 'Show in Tray',
+          type: 'checkbox',
+          checked: preferences.minimizeToTray(),
+          click() {
+            let toTray = !preferences.minimizeToTray()
+            preferences.toggleMinimizeToTray()
+      
+            if (!toTray && tray != null) {
+              tray.destroy()
+            } else {
+              tray = buildTray(windowProvider, webSocket)
+            }
+          }
+        } ]
+      }, {
       label: 'Edit',
       submenu: [
         { role: 'undo' },
@@ -233,7 +231,7 @@ var preferencesMenu = {
       click: () => {
         showPoupWindow(windowProvider)
       }
-    }, preferencesMenu, {
+    }, notificationPreferencesMenu, {
       label: 'Quit',
       accelerator: 'Command+Q',
       click: () => {

--- a/resources/js/menu.js
+++ b/resources/js/menu.js
@@ -13,8 +13,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 const preferences = require('./preferences.js')
 
+// Save the notification preferences menu to be able to snooze and set other options via
+//  both the tray icon and GUI
 var notificationPreferencesMenu = {
     label: 'Notification Preferences',
     submenu: [
@@ -49,6 +52,25 @@ var notificationPreferencesMenu = {
     }
   ]
 };
+
+if (process.platform !== "win32") {
+  notificationPreferencesMenu.submenu.push({
+    label: 'Show Unread Count on Icon',
+    type: 'checkbox',
+    checked: preferences.badgeDockIcon(),
+    click() {
+      let badge = !preferences.badgeDockIcon()
+      preferences.toggleBadgeDockIcon()
+
+      if (!badge) {
+        require('electron').app.setBadgeCount(0)
+        if (process.platform === 'darwin' && tray != null) {
+          tray.setTitle("")
+        }
+      }
+    }
+  })
+}
 
 (function() {
   const { BrowserView, Menu, Tray, app } = require('electron')
@@ -124,25 +146,6 @@ var notificationPreferencesMenu = {
         { label: 'Get it on Google Play', click() { require('electron').shell.openExternal('https://play.google.com/store/apps/details?id=xyz.klinker.messenger') } }
       ]
     }]
-
-    if (process.platform !== "win32") {
-      template[0].submenu.push({
-        label: 'Show Unread Count on Icon',
-        type: 'checkbox',
-        checked: preferences.badgeDockIcon(),
-        click() {
-          let badge = !preferences.badgeDockIcon()
-          preferences.toggleBadgeDockIcon()
-
-          if (!badge) {
-            require('electron').app.setBadgeCount(0)
-            if (process.platform === 'darwin' && tray != null) {
-              tray.setTitle("")
-            }
-          }
-        }
-      })
-    }
 
     if (process.platform === 'darwin') {
       const name = require('electron').app.getName()

--- a/resources/js/menu.js
+++ b/resources/js/menu.js
@@ -53,25 +53,6 @@ var notificationPreferencesMenu = {
   ]
 };
 
-if (process.platform !== "win32") {
-  notificationPreferencesMenu.submenu.push({
-    label: 'Show Unread Count on Icon',
-    type: 'checkbox',
-    checked: preferences.badgeDockIcon(),
-    click() {
-      let badge = !preferences.badgeDockIcon()
-      preferences.toggleBadgeDockIcon()
-
-      if (!badge) {
-        require('electron').app.setBadgeCount(0)
-        if (process.platform === 'darwin' && tray != null) {
-          tray.setTitle("")
-        }
-      }
-    }
-  })
-}
-
 (function() {
   const { BrowserView, Menu, Tray, app } = require('electron')
 
@@ -191,6 +172,25 @@ if (process.platform !== "win32") {
           windowProvider.getWindow().setMenuBarVisibility(!autoHide)
 
           browserviewPreparer.prepare(windowProvider.getWindow(), windowProvider.getBrowserView())
+        }
+      })
+    }
+
+    if (process.platform !== "win32") {
+      template[0].submenu.push({
+        label: 'Show Unread Count on Icon',
+        type: 'checkbox',
+        checked: preferences.badgeDockIcon(),
+        click() {
+          let badge = !preferences.badgeDockIcon()
+          preferences.toggleBadgeDockIcon()
+    
+          if (!badge) {
+            require('electron').app.setBadgeCount(0)
+            if (process.platform === 'darwin' && tray != null) {
+              tray.setTitle("")
+            }
+          }
         }
       })
     }

--- a/resources/js/menu.js
+++ b/resources/js/menu.js
@@ -13,65 +13,69 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+const preferences = require('./preferences.js')
+
+// Save the prefsMenu then reuse it later on.
+var prefsMenu = {
+  label: 'Preferences',
+  submenu: [{
+    label: 'Notification Preferences',
+    submenu: [
+      { label: "Show Notifications", type: 'checkbox', checked: preferences.showNotifications(), click() {
+        preferences.toggleShowNotifications() }
+      },
+      { label: "Play Notification Sound", type: 'checkbox', checked: preferences.notificationSounds(), click() {
+        preferences.toggleNotificationSounds() }
+      },
+      { type: 'separator' },
+      { label: "Display Sender in Notification", type: 'checkbox', checked: preferences.notificationSenderPreviews(), click() {
+        preferences.toggleNotificationSenderPreviews() }
+      },
+      { label: "Display Message Preview in Notification", type: 'checkbox', checked: preferences.notificationMessagePreviews(), click() {
+        preferences.toggleNotificationMessagePreviews() }
+      },
+      { type: 'separator' },
+      { label: "Snooze Desktop Notifications", submenu: [
+        { label: "30 mins", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "30_mins", click() {
+          preferences.snooze("30_mins") }
+        },
+        { label: "1 hour", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "1_hour", click() {
+          preferences.snooze("1_hour") }
+        },
+        { label: "3 hours", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "3_hours", click() {
+          preferences.snooze("3_hours") }
+        },
+        { label: "12 hours", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "12_hours", click() {
+          preferences.snooze("12_hours") }
+        }
+      ] }
+    ]
+  }, { type: 'separator' }, {
+    label: process.platform === 'darwin' ? 'Show in Menu Bar' : 'Show in Tray',
+    type: 'checkbox',
+    checked: preferences.minimizeToTray(),
+    click() {
+      let toTray = !preferences.minimizeToTray()
+      preferences.toggleMinimizeToTray()
+
+      if (!toTray && tray != null) {
+        tray.destroy()
+      } else {
+        tray = buildTray(windowProvider, webSocket)
+      }
+    }
+  } ]
+};
 
 (function() {
   const { BrowserView, Menu, Tray, app } = require('electron')
 
   const path = require('path')
-  const preferences = require('./preferences.js')
   const browserviewPreparer = require('./browserview-configurator.js')
 
   var buildMenu = (windowProvider, tray, webSocket) => {
-    const template = [{
-      label: 'Preferences',
-      submenu: [{
-        label: 'Notification Preferences',
-        submenu: [
-          { label: "Show Notifications", type: 'checkbox', checked: preferences.showNotifications(), click() {
-            preferences.toggleShowNotifications() }
-          },
-          { label: "Play Notification Sound", type: 'checkbox', checked: preferences.notificationSounds(), click() {
-            preferences.toggleNotificationSounds() }
-          },
-          { type: 'separator' },
-          { label: "Display Sender in Notification", type: 'checkbox', checked: preferences.notificationSenderPreviews(), click() {
-            preferences.toggleNotificationSenderPreviews() }
-          },
-          { label: "Display Message Preview in Notification", type: 'checkbox', checked: preferences.notificationMessagePreviews(), click() {
-            preferences.toggleNotificationMessagePreviews() }
-          },
-          { type: 'separator' },
-          { label: "Snooze Desktop Notifications", submenu: [
-            { label: "30 mins", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "30_mins", click() {
-              preferences.snooze("30_mins") }
-            },
-            { label: "1 hour", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "1_hour", click() {
-              preferences.snooze("1_hour") }
-            },
-            { label: "3 hours", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "3_hours", click() {
-              preferences.snooze("3_hours") }
-            },
-            { label: "12 hours", type: 'checkbox', checked: preferences.isSnoozeActive() && preferences.currentSnoozeSelection() == "12_hours", click() {
-              preferences.snooze("12_hours") }
-            }
-          ] }
-        ]
-      }, { type: 'separator' }, {
-        label: process.platform === 'darwin' ? 'Show in Menu Bar' : 'Show in Tray',
-        type: 'checkbox',
-        checked: preferences.minimizeToTray(),
-        click() {
-          let toTray = !preferences.minimizeToTray()
-          preferences.toggleMinimizeToTray()
-
-          if (!toTray && tray != null) {
-            tray.destroy()
-          } else {
-            tray = buildTray(windowProvider, webSocket)
-          }
-        }
-      } ]
-    }, {
+    const template = [
+      prefsMenu, {
       label: 'Edit',
       submenu: [
         { role: 'undo' },
@@ -222,7 +226,9 @@
       click: () => {
         showWindow(windowProvider)
       }
-    }, {
+    }, 
+    prefsMenu,
+    {
       label: 'Quit',
       accelerator: 'Command+Q',
       click: () => {

--- a/resources/js/menu.js
+++ b/resources/js/menu.js
@@ -15,8 +15,9 @@
  */
 const preferences = require('./preferences.js')
 
-// Save the prefsMenu then reuse it later on.
-var prefsMenu = {
+// Save the preferencesMenu then reuse it later on.
+// This way we can use the same menu in the GUI and on the tray
+var preferencesMenu = {
   label: 'Preferences',
   submenu: [{
     label: 'Notification Preferences',
@@ -75,7 +76,7 @@ var prefsMenu = {
 
   var buildMenu = (windowProvider, tray, webSocket) => {
     const template = [
-      prefsMenu, {
+      preferencesMenu, {
       label: 'Edit',
       submenu: [
         { role: 'undo' },
@@ -227,13 +228,12 @@ var prefsMenu = {
         showWindow(windowProvider)
       }
     }, 
-    prefsMenu,
     {
       label: 'Show Popup Window',
       click: () => {
         showPoupWindow(windowProvider)
       }
-    }, {
+    }, preferencesMenu, {
       label: 'Quit',
       accelerator: 'Command+Q',
       click: () => {

--- a/resources/js/notifier.js
+++ b/resources/js/notifier.js
@@ -64,7 +64,6 @@
       currentNotification.close()
     }
 
-    console.log("Notification options: " + JSON.stringify(options))
     currentNotification = new Notification(options)
 
     currentNotification.on('reply', (event, reply) => {

--- a/resources/js/notifier.js
+++ b/resources/js/notifier.js
@@ -64,6 +64,7 @@
       currentNotification.close()
     }
 
+    console.log("Notification options: " + JSON.stringify(options))
     currentNotification = new Notification(options)
 
     currentNotification.on('reply', (event, reply) => {


### PR DESCRIPTION
I wanted the ability to quickly snooze without having to open the GUI and see my messages. It's a nice feature when someone comes to your desk and you'd like popups to not come up. :) 

Anyways, this pull request duplicates the preferences menu since I figure more than snooze may be useful to be able to change without opening the whole interface.