### PR TITLE
Add the ability to use a proxy for backend communication

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,21 @@
     "appId": "xyz.klinker.messenger",
     "productName": "Pulse SMS",
     "asar": true,
-    "asarUnpack": [ "**/dict/*" ],
+    "asarUnpack": [
+      "**/dict/*"
+    ],
     "artifactName": "pulse-sms-${version}-${arch}.${ext}",
     "mac": {
       "category": "public.app-category.utilities"
     },
-    "publish": [{
-      "provider": "github",
-      "owner": "klinker24",
-      "repo": "messenger-desktop",
-      "releaseType": "draft"
-    }]
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "klinker24",
+        "repo": "messenger-desktop",
+        "releaseType": "draft"
+      }
+    ]
   },
   "devDependencies": {
     "electron": "2.0.0-beta.7",
@@ -50,6 +54,7 @@
     "electron-updater": "2.20.1",
     "electron-hunspell": "0.0.7",
     "hazardous": "0.3.0",
-    "ws": "3.2.0"
+    "ws": "3.2.0",
+    "https-proxy-agent": "2.2.1"
   }
 }

--- a/resources/js/notifier.js
+++ b/resources/js/notifier.js
@@ -20,15 +20,14 @@
   const path = require('path')
   const url = require('url')
   const https = require('https')
-  const HttpsProxyAgent = require('https-proxy-agent')
   const storage = require('electron-json-storage')
   const encrypt = require('./decrypt.js')
   const preferences = require('./preferences.js')
+  const preparer = require('./websocket-preparer.js')
 
   let lastNotificationTime = new Date().getTime()
   let currentNotification = null
   let windowProvider = null
-  let proxyAgent = null
 
   var notify = (title, snippet, conversation_id, provider) => {
     windowProvider = provider
@@ -147,7 +146,7 @@
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
         },
-        agent: getProxyAgent()
+        agent: preparer.getProxyAgent()
       }
 
       var req = https.request(options)
@@ -176,7 +175,7 @@
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
         },
-        agent: getProxyAgent()
+        agent: preparer.getProxyAgent()
       }
 
       var req = https.request(options)
@@ -204,7 +203,7 @@
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
         },
-        agent: getProxyAgent()
+        agent: preparer.getProxyAgent()
       }
 
       var req = https.request(options)
@@ -226,17 +225,5 @@
     return getRandomInt(1, 922337203685477)
   }
 
-  function getProxyAgent() {
-    // use the PULSE_PROXY or HTTPS_PROXY environment variable to determine if we should use a proxy
-    var envProxy = process.env.PULSE_PROXY || process.env.HTTPS_PROXY
-    if (!proxyAgent && envProxy) {
-      console.log("Attempting to get a proxy agent with \"" + envProxy + "\"")
-      proxyAgent = HttpsProxyAgent(envProxy)
-    }
-
-    return proxyAgent
-  }
-
   module.exports.notify = notify
-  module.exports.getProxyAgent = getProxyAgent
 }())

--- a/resources/js/notifier.js
+++ b/resources/js/notifier.js
@@ -20,6 +20,7 @@
   const path = require('path')
   const url = require('url')
   const https = require('https')
+  const HttpsProxyAgent = require('https-proxy-agent')
   const storage = require('electron-json-storage')
   const encrypt = require('./decrypt.js')
   const preferences = require('./preferences.js')
@@ -27,6 +28,7 @@
   let lastNotificationTime = new Date().getTime()
   let currentNotification = null
   let windowProvider = null
+  let proxyAgent = null
 
   var notify = (title, snippet, conversation_id, provider) => {
     windowProvider = provider
@@ -144,7 +146,8 @@
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
-        }
+        },
+        agent: getProxyAgent()
       }
 
       var req = https.request(options)
@@ -172,7 +175,8 @@
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
-        }
+        },
+        agent: getProxyAgent()
       }
 
       var req = https.request(options)
@@ -199,7 +203,8 @@
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(data)
-        }
+        },
+        agent: getProxyAgent()
       }
 
       var req = https.request(options)
@@ -221,5 +226,17 @@
     return getRandomInt(1, 922337203685477)
   }
 
+  function getProxyAgent() {
+    // use the PULSE_PROXY or HTTPS_PROXY environment variable to determine if we should use a proxy
+    var envProxy = process.env.PULSE_PROXY || process.env.HTTPS_PROXY
+    if (!proxyAgent && envProxy) {
+      console.log("Attempting to get a proxy agent with \"" + envProxy + "\"")
+      proxyAgent = HttpsProxyAgent(envProxy)
+    }
+
+    return proxyAgent
+  }
+
   module.exports.notify = notify
+  module.exports.getProxyAgent = getProxyAgent
 }())

--- a/resources/js/websocket-preparer.js
+++ b/resources/js/websocket-preparer.js
@@ -17,7 +17,10 @@
  (function() {
 
   const storage = require('electron-json-storage')
+  const HttpsProxyAgent = require('https-proxy-agent')
   const debug = false
+
+  let proxyAgent = null
 
   var prepare = (browser) => {
     browser.webContents.executeJavaScript('accountId', true).then((id) => {
@@ -42,5 +45,17 @@
     }
   }
 
+  function getProxyAgent() {
+    // use the PULSE_PROXY or HTTPS_PROXY environment variable to determine if we should use a proxy
+    var envProxy = process.env.PULSE_PROXY || process.env.HTTPS_PROXY
+    if (!proxyAgent && envProxy) {
+      console.log("Attempting to get a proxy agent with \"" + envProxy + "\"")
+      proxyAgent = HttpsProxyAgent(envProxy)
+    }
+
+    return proxyAgent
+  }
+
   module.exports.prepare = prepare
+  module.exports.getProxyAgent = getProxyAgent
 }())

--- a/resources/js/websocket.js
+++ b/resources/js/websocket.js
@@ -61,7 +61,7 @@
   function open(account_id) {
     closeWebSocket()
 
-    socket = new WebSocket("wss://api.messenger.klinkerapps.com/api/v1/stream?account_id=" + account_id, {agent: notifier.getProxyAgent()})
+    socket = new WebSocket("wss://api.messenger.klinkerapps.com/api/v1/stream?account_id=" + account_id, {agent: preparer.getProxyAgent()})
 
     socket.on("error", (err) =>  {
       console.log("ws error: " + err)
@@ -252,7 +252,7 @@
 
   function getJSON(urlToGet, successHandler) {
     var options = url.parse(urlToGet)
-    options.agent = notifier.getProxyAgent()
+    options.agent = preparer.getProxyAgent()
     var req = https.get(options, (response) => {
       var body = ''
       response.on('data', (d) => {


### PR DESCRIPTION
I had emailed @klinker24 a few weeks ago about my notifications not working. Anyways I debugged and figured out it was because the ws connection was failing and then latter https requests were failing. I was on a system which needed a proxy to connect. 

This PR adds the ability to use either PULSE_PROXY or HTTPS_PROXY environment variables to use a proxy so that notifications can still work on corporate (or any proxy) environment.

The reason I have 2 environment variables is because HTTPS_PROXY is sort-of standard and PULSE_PROXY because I don't really want to use HTTPS_PROXY because since it is standard it messes with other application behavior.

On my Windows system this works perfectly now with PULSE_PROXY set.