### PR TITLE
Improvements around hiding the Windows/Linux menu bar

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -290,47 +290,33 @@ export default class PulseMenu {
         { label: "Bring All to Front", role: "front" },
       ];
     } else {
-      template[0].submenu.push({
-        checked: this.preferences.autoHideMenuBar(),
+      // Windows menu
+      template[3].submenu.push({ type: "separator" });
+      template[3].submenu.push({
+        accelerator: "Alt+M",
         click: (): void => {
-          const autoHide = !this.preferences.autoHideMenuBar();
-          this.preferences.toggleAutoHideMenuBar();
+          const win = windowProvider.getWindow();
+          const menuVisible = win.isMenuBarVisible();
 
-          windowProvider.getWindow().setAutoHideMenuBar(autoHide);
-          windowProvider.getWindow().setMenuBarVisibility(!autoHide);
+          win.setAutoHideMenuBar(menuVisible);
+          win.setMenuBarVisibility(!menuVisible);
 
-          this.browserviewPreparer.setBounds(windowProvider.getWindow(), windowProvider.getBrowserView());
+          this.preferences.toggleHideMenuBar();
+          this.browserviewPreparer.setBounds(win, windowProvider.getBrowserView());
         },
-        label: "Auto-hide Menu Bar",
-        type: "checkbox",
-      });
-
-      globalShortcut.register("Alt+M", () => {
-        if (!this.preferences.autoHideMenuBar()) {
-          return;
-        }
-
-        const window = windowProvider.getWindow();
-        if (window.isMenuBarVisible()) {
-          window.setAutoHideMenuBar(true);
-          window.setMenuBarVisibility(false);
-        } else {
-          window.setAutoHideMenuBar(false);
-          window.setMenuBarVisibility(true);
-        }
-
-        this.browserviewPreparer.setBounds(window, windowProvider.getBrowserView());
+        label: "Toggle Menu Bar Visibility",
       });
     }
 
+    const window = windowProvider.getWindow();
+    const hideMenuBar = this.preferences.hideMenuBar();
     const menu = Menu.buildFromTemplate(template);
-    Menu.setApplicationMenu(menu);
 
-    // if they turn on auto hide, then this should be hidden.
-    // if they turn off auto hide, we will show this menu bar immediately.
-    windowProvider.getWindow().setMenuBarVisibility(!this.preferences.autoHideMenuBar());
-    windowProvider.getWindow().setAutoHideMenuBar(this.preferences.autoHideMenuBar());
-    this.browserviewPreparer.setBounds(windowProvider.getWindow(), windowProvider.getBrowserView());
+    Menu.setApplicationMenu(menu);
+    window.setAutoHideMenuBar(hideMenuBar);
+    window.setMenuBarVisibility(!hideMenuBar);
+
+    this.browserviewPreparer.setBounds(window, windowProvider.getBrowserView());
   }
 
   public buildTray = (windowProvider: WindowProvider, webSocket: PulseWebSocket) => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -221,17 +221,15 @@ export default class PulseMenu {
             type: "info",
           };
 
-          try {
-            dialog.showMessageBox(null, dialogOpts)
-              .then((value: MessageBoxReturnValue) => {
-                if (value.response === 0) {
-                  webSocket.closeWebSocket();
-                  app.exit(0);
-                }
-              });
-          } catch (err) {
-            // no-op
-          }
+          dialog.showMessageBox(null, dialogOpts)
+            .then((value: MessageBoxReturnValue) => {
+              if (value.response === 0) {
+                webSocket.closeWebSocket();
+                app.exit(0);
+              }
+            }).catch(() => {
+              // no-op
+            });
         },
         label: "Use Spellcheck",
         type: "checkbox",
@@ -303,6 +301,17 @@ export default class PulseMenu {
 
           this.preferences.toggleHideMenuBar();
           this.browserviewPreparer.setBounds(win, windowProvider.getBrowserView());
+
+          if (menuVisible && !this.preferences.seenMenuBarWarning()) {
+            const dialogOpts = {
+              buttons: ["OK"],
+              message: "Tapping Alt+M will allow you to toggle whether or not the menu bar is displayed.",
+              title: "Showing the Menu Bar",
+              type: "info",
+            };
+
+            dialog.showMessageBox(null, dialogOpts);
+          }
         },
         label: "Toggle Menu Bar Visibility",
       });

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -311,6 +311,7 @@ export default class PulseMenu {
             };
 
             dialog.showMessageBox(null, dialogOpts);
+            this.preferences.toggleSeenMenuBarWarning();
           }
         },
         label: "Toggle Menu Bar Visibility",

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import { app, dialog, Menu, MessageBoxReturnValue, Tray } from "electron";
+import { app, dialog, globalShortcut, Menu, MessageBoxReturnValue, Tray } from "electron";
 import * as path from "path";
 
 import DesktopPreferences from "./preferences";
@@ -303,6 +303,23 @@ export default class PulseMenu {
         },
         label: "Auto-hide Menu Bar",
         type: "checkbox",
+      });
+
+      globalShortcut.register("Alt+M", () => {
+        if (!this.preferences.autoHideMenuBar()) {
+          return;
+        }
+
+        const window = windowProvider.getWindow();
+        if (window.isMenuBarVisible()) {
+          window.setAutoHideMenuBar(true);
+          window.setMenuBarVisibility(false);
+        } else {
+          window.setAutoHideMenuBar(false);
+          window.setMenuBarVisibility(true);
+        }
+
+        this.browserviewPreparer.setBounds(window, windowProvider.getBrowserView());
       });
     }
 

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -299,7 +299,7 @@ export default class PulseMenu {
           windowProvider.getWindow().setAutoHideMenuBar(autoHide);
           windowProvider.getWindow().setMenuBarVisibility(!autoHide);
 
-          this.browserviewPreparer.prepare(windowProvider.getWindow(), windowProvider.getBrowserView());
+          this.browserviewPreparer.setBounds(windowProvider.getWindow(), windowProvider.getBrowserView());
         },
         label: "Auto-hide Menu Bar",
         type: "checkbox",
@@ -313,6 +313,7 @@ export default class PulseMenu {
     // if they turn off auto hide, we will show this menu bar immediately.
     windowProvider.getWindow().setMenuBarVisibility(!this.preferences.autoHideMenuBar());
     windowProvider.getWindow().setAutoHideMenuBar(this.preferences.autoHideMenuBar());
+    this.browserviewPreparer.setBounds(windowProvider.getWindow(), windowProvider.getBrowserView());
   }
 
   public buildTray = (windowProvider: WindowProvider, webSocket: PulseWebSocket) => {
@@ -383,4 +384,3 @@ export default class PulseMenu {
   }
 
 }
-

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -24,6 +24,7 @@ export default class DesktopPreferences {
 
   // Boolean Preference: Default to FALSE
   private static HIDE_MENU_BAR = "hide-menu-bar";
+  private static SEEN_MENU_BAR_WARNING = "seen-menu-bar-warning";
 
   // Boolean Preference: Default to TRUE
   private static SHOW_NOTIFICATIONS = "show-notifications";
@@ -79,6 +80,11 @@ export default class DesktopPreferences {
       settings.get(DesktopPreferences.HIDE_MENU_BAR) === "true"
   )
 
+  public seenMenuBarWarning = (): boolean => (
+    settings.has(DesktopPreferences.SEEN_MENU_BAR_WARNING) &&
+      settings.get(DesktopPreferences.SEEN_MENU_BAR_WARNING) === "true"
+  )
+
   public showNotifications = (): boolean => (
     !settings.has(DesktopPreferences.SHOW_NOTIFICATIONS) ||
       settings.get(DesktopPreferences.SHOW_NOTIFICATIONS) === "true"
@@ -121,6 +127,10 @@ export default class DesktopPreferences {
 
   public toggleHideMenuBar = (): void => {
     this.togglePreference(DesktopPreferences.HIDE_MENU_BAR, this.hideMenuBar);
+  }
+
+  public toggleSeenMenuBarWarning = (): void => {
+    this.togglePreference(DesktopPreferences.SEEN_MENU_BAR_WARNING, this.seenMenuBarWarning);
   }
 
   public toggleShowNotifications = (): void => {

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -23,7 +23,7 @@ export default class DesktopPreferences {
   private static SNOOZE_PREFERENCE = "snooze-selected-preference";
 
   // Boolean Preference: Default to FALSE
-  private static AUTO_HIDE_MENU_BAR = "auto-hide-menu-bar";
+  private static HIDE_MENU_BAR = "hide-menu-bar";
 
   // Boolean Preference: Default to TRUE
   private static SHOW_NOTIFICATIONS = "show-notifications";
@@ -74,9 +74,9 @@ export default class DesktopPreferences {
     }
   }
 
-  public autoHideMenuBar = (): boolean => (
-    settings.has(DesktopPreferences.AUTO_HIDE_MENU_BAR) &&
-      settings.get(DesktopPreferences.AUTO_HIDE_MENU_BAR) === "true"
+  public hideMenuBar = (): boolean => (
+    settings.has(DesktopPreferences.HIDE_MENU_BAR) &&
+      settings.get(DesktopPreferences.HIDE_MENU_BAR) === "true"
   )
 
   public showNotifications = (): boolean => (
@@ -119,8 +119,8 @@ export default class DesktopPreferences {
       settings.get(DesktopPreferences.MINIMIZE_TO_TRAY) === "true"
   )
 
-  public toggleAutoHideMenuBar = (): void => {
-    this.togglePreference(DesktopPreferences.AUTO_HIDE_MENU_BAR, this.autoHideMenuBar);
+  public toggleHideMenuBar = (): void => {
+    this.togglePreference(DesktopPreferences.HIDE_MENU_BAR, this.hideMenuBar);
   }
 
   public toggleShowNotifications = (): void => {

--- a/src/window/browserview-preparer.ts
+++ b/src/window/browserview-preparer.ts
@@ -26,13 +26,8 @@ export default class BrowserViewPreparer {
   private preferences = new DesktopPreferences();
 
   public prepare = (window: BrowserWindow, browser: BrowserView) => {
-    browser.setBounds({
-      height: window.getBounds().height - this.getTitleBarSize(window),
-      width: window.getBounds().width,
-      x: 0,
-      y: 0,
-    });
-    browser.setAutoResize( { width: true, height: true, horizontal: false, vertical: false } );
+    this.setBounds(window, browser);
+    browser.setAutoResize( { width: true, height: true, horizontal: false, vertical: true } );
     browser.webContents.loadURL("https://pulsesms.app");
 
     browser.webContents.on("dom-ready", (event: Event): void => {
@@ -57,13 +52,30 @@ export default class BrowserViewPreparer {
     this.spellCheck.prepareMenu(window, browser);
   }
 
+  public setBounds = (window: BrowserWindow, browser: BrowserView) => {
+    browser.setBounds({
+      height: window.getBounds().height - this.getTitleBarSize(window),
+      width: window.getBounds().width,
+      x: 0,
+      y: this.getYOffset(window),
+    });
+  }
+
+  private getYOffset = (window: BrowserWindow): number => {
+    if (process.platform === "darwin") {
+      return 0;
+    }
+
+    return window.isMenuBarVisible() ? 20 : 0
+  }
+
   private getTitleBarSize = (window: BrowserWindow): number => {
     if (process.platform === "darwin") {
       return 20;
     } else if (process.platform === "win32") {
-      return this.preferences.autoHideMenuBar() ? 40 : 60;
+      return window.isMenuBarVisible() ? 40 : 60;
     } else {
-      return 0;
+      return window.isMenuBarVisible() ? 20 : 0;
     }
   }
 

--- a/src/window/browserview-preparer.ts
+++ b/src/window/browserview-preparer.ts
@@ -57,25 +57,17 @@ export default class BrowserViewPreparer {
       height: window.getBounds().height - this.getTitleBarSize(window),
       width: window.getBounds().width,
       x: 0,
-      y: this.getYOffset(window),
+      y: 0,
     });
-  }
-
-  private getYOffset = (window: BrowserWindow): number => {
-    if (process.platform === "darwin" || !this.preferences.autoHideMenuBar()) {
-      return 0;
-    }
-
-    return window.isMenuBarVisible() ? 20 : 0;
   }
 
   private getTitleBarSize = (window: BrowserWindow): number => {
     if (process.platform === "darwin") {
       return 20;
     } else if (process.platform === "win32") {
-      return this.preferences.autoHideMenuBar() && !window.isMenuBarVisible() ? 40 : 60;
+      return !window.isMenuBarVisible() ? 40 : 60;
     } else {
-      return this.preferences.autoHideMenuBar() && window.isMenuBarVisible() ? 20 : 0;
+      return window.isMenuBarVisible() ? 20 : 0;
     }
   }
 

--- a/src/window/browserview-preparer.ts
+++ b/src/window/browserview-preparer.ts
@@ -73,7 +73,7 @@ export default class BrowserViewPreparer {
     if (process.platform === "darwin") {
       return 20;
     } else if (process.platform === "win32") {
-      return this.preferences.autoHideMenuBar() && window.isMenuBarVisible() ? 40 : 60;
+      return this.preferences.autoHideMenuBar() && !window.isMenuBarVisible() ? 40 : 60;
     } else {
       return this.preferences.autoHideMenuBar() && window.isMenuBarVisible() ? 20 : 0;
     }

--- a/src/window/browserview-preparer.ts
+++ b/src/window/browserview-preparer.ts
@@ -65,7 +65,7 @@ export default class BrowserViewPreparer {
     if (process.platform === "darwin") {
       return 20;
     } else if (process.platform === "win32") {
-      return !window.isMenuBarVisible() ? 40 : 60;
+      return window.isMenuBarVisible() ? 60 : 40;
     } else {
       return window.isMenuBarVisible() ? 20 : 0;
     }

--- a/src/window/browserview-preparer.ts
+++ b/src/window/browserview-preparer.ts
@@ -62,20 +62,20 @@ export default class BrowserViewPreparer {
   }
 
   private getYOffset = (window: BrowserWindow): number => {
-    if (process.platform === "darwin") {
+    if (process.platform === "darwin" || !this.preferences.autoHideMenuBar()) {
       return 0;
     }
 
-    return window.isMenuBarVisible() ? 20 : 0
+    return window.isMenuBarVisible() ? 20 : 0;
   }
 
   private getTitleBarSize = (window: BrowserWindow): number => {
     if (process.platform === "darwin") {
       return 20;
     } else if (process.platform === "win32") {
-      return window.isMenuBarVisible() ? 40 : 60;
+      return this.preferences.autoHideMenuBar() && window.isMenuBarVisible() ? 40 : 60;
     } else {
-      return window.isMenuBarVisible() ? 20 : 0;
+      return this.preferences.autoHideMenuBar() && window.isMenuBarVisible() ? 20 : 0;
     }
   }
 

--- a/src/window/window-provider.ts
+++ b/src/window/window-provider.ts
@@ -41,7 +41,6 @@ export default class WindowProvider {
     try {
       mainWindowState = windowStateKeeper( { defaultWidth: 1000, defaultHeight: 750 } );
       bounds = {
-        autoHideMenuBar: this.preferences.autoHideMenuBar(),
         height: mainWindowState.height,
         icon: path.join(__dirname, "../build/icon.png"),
         minHeight: 300,
@@ -54,7 +53,6 @@ export default class WindowProvider {
       };
     } catch (err) {
       bounds = {
-        autoHideMenuBar: this.preferences.autoHideMenuBar(),
         height: 750,
         icon: path.join(__dirname, "../build/icon.png"),
         minHeight: 300,

--- a/src/window/window-provider.ts
+++ b/src/window/window-provider.ts
@@ -41,6 +41,7 @@ export default class WindowProvider {
     try {
       mainWindowState = windowStateKeeper( { defaultWidth: 1000, defaultHeight: 750 } );
       bounds = {
+        autoHideMenuBar: this.preferences.autoHideMenuBar(),
         height: mainWindowState.height,
         icon: path.join(__dirname, "../build/icon.png"),
         minHeight: 300,
@@ -53,6 +54,7 @@ export default class WindowProvider {
       };
     } catch (err) {
       bounds = {
+        autoHideMenuBar: this.preferences.autoHideMenuBar(),
         height: 750,
         icon: path.join(__dirname, "../build/icon.png"),
         minHeight: 300,


### PR DESCRIPTION
* **Windows** and **Linux**: the "auto-hide menu bar" functionality has slightly changed. 
  * There is no more preference for this under the "Preferences" menu item. 
  * Under "Window" there is a preference to "Toggle menu bar visibility". Pressing this will turn the menu bar on/off
  * You can press "Alt+M" to show or hide the menu bar now, instead of just "Alt"
  * This change was made to alleviate many of the layout issues caused by this old preference. 

This will close https://github.com/klinker-apps/messenger-issues/issues/709