### PR TITLE
Notifications: Add Option for Auto-Dismissal

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -50,6 +50,8 @@ export default class PulseMenu {
         },
         label: "Auto-Dismiss Notifications",
         type: "checkbox",
+        // `timeoutType` is only applicable to Windows and Linux systems
+        visible: process.platform !== "darwin"
       }, { type: "separator" }, {
         checked: this.preferences.notificationSenderPreviews(),
         click: (): void => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -43,6 +43,13 @@ export default class PulseMenu {
         },
         label: "Play Notification Sound",
         type: "checkbox",
+      }, {
+        checked: this.preferences.autoDismissNotifications(),
+        click: (): void => {
+          this.preferences.toggleAutoDismissNotifications();
+        },
+        label: "Auto-Dismiss Notifications",
+        type: "checkbox",
       }, { type: "separator" }, {
         checked: this.preferences.notificationSenderPreviews(),
         click: (): void => {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -61,7 +61,7 @@ export default class Notifier {
       hasReply: !isPrivate,
       replyPlaceholder: "Reply to " + title,
       silent: !this.preferences.notificationSounds(),
-      timeoutType: "never",
+      timeoutType: this.preferences.autoDismissNotifications() ? "default" : "never",
       title,
     };
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -25,11 +25,11 @@ export default class DesktopPreferences {
   // Boolean Preference: Default to FALSE
   private static HIDE_MENU_BAR = "hide-menu-bar";
   private static SEEN_MENU_BAR_WARNING = "seen-menu-bar-warning";
+  private static AUTO_DISMISS_NOTIFICATIONS = "auto-dismiss-notifications";
 
   // Boolean Preference: Default to TRUE
   private static SHOW_NOTIFICATIONS = "show-notifications";
   private static NOTIFICATION_SOUNDS = "notification-sounds";
-  private static AUTO_DISMISS_NOTIFICATIONS = "auto-dismiss-notifications";
   private static NOTIFICATION_SENDER_PREVIEWS = "notification-sender-previews";
   private static NOTIFICATION_MESSAGE_PREVIEWS = "notification-message-previews";
   private static BADGE_DOCK_ICON = "badge-dock-icon";

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -29,7 +29,7 @@ export default class DesktopPreferences {
   // Boolean Preference: Default to TRUE
   private static SHOW_NOTIFICATIONS = "show-notifications";
   private static NOTIFICATION_SOUNDS = "notification-sounds";
-  private static AUTO_DISMISS_NOTIFICATIONS = "notification-timeout-type";
+  private static AUTO_DISMISS_NOTIFICATIONS = "auto-dismiss-notifications";
   private static NOTIFICATION_SENDER_PREVIEWS = "notification-sender-previews";
   private static NOTIFICATION_MESSAGE_PREVIEWS = "notification-message-previews";
   private static BADGE_DOCK_ICON = "badge-dock-icon";

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -29,6 +29,7 @@ export default class DesktopPreferences {
   // Boolean Preference: Default to TRUE
   private static SHOW_NOTIFICATIONS = "show-notifications";
   private static NOTIFICATION_SOUNDS = "notification-sounds";
+  private static AUTO_DISMISS_NOTIFICATIONS = "notification-timeout-type";
   private static NOTIFICATION_SENDER_PREVIEWS = "notification-sender-previews";
   private static NOTIFICATION_MESSAGE_PREVIEWS = "notification-message-previews";
   private static BADGE_DOCK_ICON = "badge-dock-icon";
@@ -95,6 +96,11 @@ export default class DesktopPreferences {
       settings.get(DesktopPreferences.NOTIFICATION_SOUNDS) === "true"
   )
 
+  public autoDismissNotifications = (): boolean => (
+    settings.has(DesktopPreferences.AUTO_DISMISS_NOTIFICATIONS) &&
+      settings.get(DesktopPreferences.AUTO_DISMISS_NOTIFICATIONS) === "true"
+  )
+
   public notificationSenderPreviews = (): boolean => (
     !settings.has(DesktopPreferences.NOTIFICATION_SENDER_PREVIEWS) ||
       settings.get(DesktopPreferences.NOTIFICATION_SENDER_PREVIEWS) === "true"
@@ -139,6 +145,10 @@ export default class DesktopPreferences {
 
   public toggleNotificationSounds = (): void => {
     this.togglePreference(DesktopPreferences.NOTIFICATION_SOUNDS, this.notificationSounds);
+  }
+
+  public toggleAutoDismissNotifications = (): void => {
+    this.togglePreference(DesktopPreferences.AUTO_DISMISS_NOTIFICATIONS, this.autoDismissNotifications);
   }
 
   public toggleNotificationSenderPreviews = (): void => {


### PR DESCRIPTION
Hi,

Been using Pulse for a long time, but something that's been annoying me lately is the fact that notifications don't automatically dismiss themselves. This leads them to get in the way while I'm performing other tasks, requiring manual intervention. I spent a while fighting with my system's notification settings before realizing that this was being enforced by Pulse itself.

This issue can be resolved by changing `timeoutType` to "default" instead of "never", and applies to Windows and Linux machines.

Relevant Electron documentation: https://www.electronjs.org/docs/api/notification#notificationtimeouttype-linux-windows

My implementation strategy is as follows:
- Introduce a new preferences key `auto-dismiss-notifications`
- Default this preference to false (for consistency with current behaviour)
- If `auto-dismiss-notifications` is true, set timeoutType to `"default"` in the notifier. Otherwise, set to `"never"` (current behaviour).
- Hide the preference option on darwin systems (as it's inapplicable).
  - I chose to exclude darwin instead of including all windows and linux platform, as it seemed like the route with the least points of failure

Please let me know if you'd like anything changed!

Thank you,
stupid cat