### PR TITLE
Repo URL in description 404's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 This repository just includes the `releases` of the Pulse Desktop App. Code lives in the https://github.com/maplemedia/pulse-sms-desktop-code.  
+ 


### PR DESCRIPTION
The repo URL is either wrong, or private.

Apologies for using a PR as an issue, issues are disabled in this repo, so I had no other way to contact you about this.